### PR TITLE
Fix broken help link

### DIFF
--- a/content/getting-started/installing.md
+++ b/content/getting-started/installing.md
@@ -251,7 +251,8 @@ Grails application running at http://localhost:8080 in environment: production
 
 # Next Steps
 
-Now that you've installed Streama, have a look at the [first steps][firststeps] page and explore the rest of the documentation. If you have questions, connect with the community via [Discord or GitHub][/help].
+Now that you've installed Streama, have a look at the [first steps][firststeps] page and explore the rest of the documentation. If you have questions, connect with the community via [Discord or GitHub][help].
 
 [firststeps]: /getting-started/first-steps/
 [releases]: https://github.com/streamaserver/streama/releases/
+[help]: /help


### PR DESCRIPTION
Syntax for this link was bad. I split it out into a reference link so it renders properly.