### PR TITLE
apache2 config fixes

### DIFF
--- a/content/config/proxy.md
+++ b/content/config/proxy.md
@@ -123,8 +123,8 @@ Standard Nginx SSL configurations work. Certbot can be used also.
     #Reverse proxy configuration
     #Change the port (here 8080) to whatever you define in your application.yml
     ProxyPreserveHost On
-    ProxyPass / http://127.0.0.1:8080
-    ProxyPassReverse / http://127.0.0.1:8080
+    ProxyPass / http://127.0.0.1:8080/
+    ProxyPassReverse / http://127.0.0.1:8080/
 </VirtualHost>
 ```
 
@@ -170,8 +170,8 @@ Standard Nginx SSL configurations work. Certbot can be used also.
 	SSLCertificateKeyFile "conf/ssl/my_streama.key"		# Change this to the path of your own cert.
 
 	#The actual redirection of the traffic
-	ProxyPass / https://localhost:8080/					# If you have streama running on another port than 8080, change it here.
-	ProxyPassReverse / https://localhost:8080/			# If you have streama running on another port than 8080, change it here.
+	ProxyPass / http://localhost:8080/					# If you have streama running on another port than 8080, change it here.
+	ProxyPassReverse / http://localhost:8080/			# If you have streama running on another port than 8080, change it here.
 </VirtualHost>
 ```
 


### PR DESCRIPTION
added forward slashes to end of http reverse proxy url
https-->http at bottom of SSL apache2 config