### PR TITLE
Update URL and date

### DIFF
--- a/themes/streama/layouts/partials/footer.html
+++ b/themes/streama/layouts/partials/footer.html
@@ -3,7 +3,7 @@
 
 <nav class="navbar fixed-bottom navbar-light bg-light">
     <span class="navbar-text">
-    StreamaServer.org 2018, licenced under MIT license.
+    docs.streama-project.com 2020, licenced under MIT license.
     </span>
     <span class="navbar-text">
       <a href="https://github.com/streamaserver/streamaDocs">Docs GitHub</a>


### PR DESCRIPTION
Changed url from StreamaServer.org to docs.streama-project.com and the date from 2018 to 2020